### PR TITLE
Add temporary Google Maps API access

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is a LeafletJS-based prototype of a real time map for various transit systems, including Miami-Dade Transit and various trolley services.
 
-Live demo is at http://qtrandev.github.io/LeafletTransit. Past demo is at http://www.qtrandev.com/transit
+Live demo is at http://qtrandev.github.io/LeafletTransit. Past demo is at http://www.qtrandev.com/transit2
 
 Reload the site often for the latest data to show. (Can use Shift + Reload button for full page refresh)  
 Press F12 in your browser to view the Javascript console for any errors.

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
   <script src="http://code.jquery.com/ui/1.11.4/jquery-ui.js"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
   <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.14/angular.min.js"></script>
-  <script src="http://maps.google.com/maps/api/js?v=3&sensor=false"></script>
+  <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyD8D11NU8OXfx8VqjFDR0pLcL8SK0n2ZH8"></script>
   <script src="googlemaps/Google.js"></script>
   <script src="googlemaps/GoogleTraffic.js"></script>
   <!--Add button to locate the current user-->


### PR DESCRIPTION
Due to Google Maps API charging for calls now instead of being free, adding a temporary key limited to certain websites to allow the maps to work.